### PR TITLE
added CORS to API endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,9 @@ from ucsc import ucsc
 
 from flask import Flask
 from flask_compress import Compress
+from flask_cors import CORS
 
 app = Flask(__name__)
+CORS(app, resources={r"/api": {"origins": "*"}})
 Compress(app)
 app.register_blueprint(ucsc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ charset-normalizer==2.1.1
 click==8.1.3
 css-html-js-minify==2.5.5
 Flask==2.2.2
+flask-cors==3.0.10
 Flask-Compress==1.13
 gunicorn==20.1.0
 idna==3.4


### PR DESCRIPTION
Currently the api endpoint doesn't have a CORS header which means someone developing another web app around the api endpoint would have to use a CORS proxy. To enable CORS on only the api endpoint I used the package [flask-CORS](https://flask-cors.readthedocs.io)